### PR TITLE
Enable content check mechanism

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -60,6 +60,16 @@
 			<artifactId>spring-boot-starter-test</artifactId>
 			<scope>test</scope>
 		</dependency>
+		<dependency>
+			<groupId>org.apache.httpcomponents</groupId>
+			<artifactId>httpclient</artifactId>
+			<version>4.5.13</version>
+		</dependency>
+		<dependency>
+			<groupId>com.fasterxml.jackson.core</groupId>
+			<artifactId>jackson-databind</artifactId>
+			<version>2.17.1</version>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/src/main/java/com/jialin/BulletinBoard/controller/NoteController.java
+++ b/src/main/java/com/jialin/BulletinBoard/controller/NoteController.java
@@ -30,8 +30,7 @@ public class NoteController {
     @PostMapping
     public ResponseEntity<Note> createNote(@RequestBody Note note, @RequestParam Long userId) {
         User user = _userService.getUserById(userId);
-        Note createdNote = _noteService.saveNote(note, user);
-        return ResponseEntity.ok(createdNote);
+        return _noteService.saveNote(note, user);
     }
 
     /**

--- a/src/main/java/com/jialin/BulletinBoard/service/ContentCheckService.java
+++ b/src/main/java/com/jialin/BulletinBoard/service/ContentCheckService.java
@@ -1,0 +1,80 @@
+package com.jialin.BulletinBoard.service;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpPost;
+import org.apache.http.entity.StringEntity;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClients;
+import org.apache.http.util.EntityUtils;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+/**
+ * This service checks the content of Notes
+ * By leveraging Google Perspective toxic content detector, we are able to detect the toxic contents in the notes
+ */
+@Slf4j
+@Component
+public class ContentCheckService {
+    private static final String KEY = "AIzaSyDXGi2NO6g3YduukMnd4f6EZ_TBLlikWX8";
+    private static final String PERSPECTIVE_URL =
+            "https://commentanalyzer.googleapis.com/v1alpha1/comments:analyze?key=" + KEY;
+    private static final String REQUEST_BODY = """
+            {comment: {text: "%s"},
+                   languages: ["en"],
+                   requestedAttributes: {TOXICITY:{}} }
+            """;
+
+
+    /**
+     * For any input content, validate if it's content by toxic score evaluated from Google Perspective
+     *
+     * @param content content of String to be checked by Google Perspective
+     * @return assertion on if this content is toxic
+     */
+    public boolean isToxic(String content) {
+        try (CloseableHttpClient closeableHttpClient = HttpClients.createDefault()) {
+            // Assemble POST request
+            HttpPost postRequest = new HttpPost(PERSPECTIVE_URL);
+            postRequest.setHeader("Content-Type", "application/json");
+            postRequest.setEntity(new StringEntity(String.format(REQUEST_BODY, content)));
+
+            CloseableHttpResponse response = closeableHttpClient.execute(postRequest);
+
+            String responseString = EntityUtils.toString(response.getEntity());
+            closeableHttpClient.close();
+
+            // When toxic score is higher than 0.4, we decide it's toxic content
+            return parseScore(responseString) > 0.4;
+        } catch(IOException e) {
+            log.error(e.toString());
+            throw new RuntimeException();
+        }
+    }
+
+    /**
+     * For the given response, parse the toxic score and return
+     *
+     * @param response
+     * @return toxic score of double type
+     */
+    private double parseScore(String response) {
+        ObjectMapper mapper = new ObjectMapper();
+        try {
+            JsonNode jsonNode = mapper.readTree(response);
+            return jsonNode.path("attributeScores")
+                    .path("TOXICITY")
+                    .path("summaryScore")
+                    .path("value")
+                    .asDouble();
+        } catch (JsonProcessingException e) {
+            log.error("Fail to parse toxic score for response: " + response);
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/src/main/java/com/jialin/BulletinBoard/service/NoteService.java
+++ b/src/main/java/com/jialin/BulletinBoard/service/NoteService.java
@@ -27,7 +27,7 @@ public class NoteService {
             throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Content fails to pass toxic check");
         }
         note.setCreatedBy(user);
-        return ResponseEntity.ok(note);
+        return ResponseEntity.ok(_noteRepository.save(note));
     }
 
     public List<Note> getAllNotes() {

--- a/src/main/java/com/jialin/BulletinBoard/service/NoteService.java
+++ b/src/main/java/com/jialin/BulletinBoard/service/NoteService.java
@@ -4,7 +4,10 @@ import com.jialin.BulletinBoard.models.Note;
 import com.jialin.BulletinBoard.models.User;
 import com.jialin.BulletinBoard.repository.NoteRepository;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
+import org.springframework.web.server.ResponseStatusException;
 
 import java.util.List;
 
@@ -16,10 +19,15 @@ public class NoteService {
 
     @Autowired
     private NoteRepository _noteRepository;
+    @Autowired
+    private ContentCheckService _contentCheckService;
 
-    public Note saveNote(Note note, User user) {
+    public ResponseEntity<Note> saveNote(Note note, User user) {
+        if (_contentCheckService.isToxic(note.getContent())) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Content fails to pass toxic check");
+        }
         note.setCreatedBy(user);
-        return _noteRepository.save(note);
+        return ResponseEntity.ok(note);
     }
 
     public List<Note> getAllNotes() {
@@ -41,4 +49,6 @@ public class NoteService {
     public void deleteNote(Long id) {
         _noteRepository.deleteById(id);
     }
+
+
 }

--- a/src/main/java/com/jialin/BulletinBoard/service/UserService.java
+++ b/src/main/java/com/jialin/BulletinBoard/service/UserService.java
@@ -6,6 +6,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
+import java.util.Optional;
 
 /**
  *  Handles the business logic of the application.


### PR DESCRIPTION
# Overview
- Enable toxic content detection mechanism for created contents 

# Details 
- [Prerequisite] Set up Google Perspective API at https://perspectiveapi.com/
  - Application Key is needed inside HTTP calls
- Assemble HTTP POST call with Apache HttpClient
- Parse response in the format of JSON to get the evaluation score
- Decide if the content is toxic, if yes, then fail the transaction, throw BAD_REQUEST. Otherwise, proceed the transaction.

# Tests
- [ ] Curl test

For normal content, proceed to save the Note
<img width="923" alt="image" src="https://github.com/user-attachments/assets/b74ffab8-8266-4a59-a1d9-9db03dec4100">

  For toxic content, throw exception 
<img width="929" alt="image" src="https://github.com/user-attachments/assets/0bfba8be-ab58-41bd-ab83-a21346f770ca">
